### PR TITLE
fix: group CodeQL actions to avoid failing CIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: 'weekly'
     assignees:
       - 'pandatix'
+    groups:
+      # init/autobuild/analyze must stay on the same version or CodeQL errors out
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # Node modules
   - package-ecosystem: 'npm'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters:
   default: none
   enable:
     - errcheck
-    - goconst
+    # - goconst # Disabled as we estimate it fine for such scale, plus changed behavior from previous working versions
     - gosec
     - govet
     - ineffassign


### PR DESCRIPTION
This PR fixes the issue of having many CodeQL actions bumped in different PRs by dependabot (they need to be updated at once to properly work).

Also remove `goconst` from linters, as we already do on others (e.g., Chall-Manager). This worked fine before, but they changed the behavior hence now fails.